### PR TITLE
session.py: actually call _get_default_session()

### DIFF
--- a/localstack_client/session.py
+++ b/localstack_client/session.py
@@ -59,8 +59,8 @@ def _get_default_session():
 
 
 def client(*args, **kwargs):
-    return _get_default_session.client(*args, **kwargs)
+    return _get_default_session().client(*args, **kwargs)
 
 
 def resource(*args, **kwargs):
-    return _get_default_session.resource(*args, **kwargs)
+    return _get_default_session().resource(*args, **kwargs)


### PR DESCRIPTION
Doesn't actually call _get_default_session()