### PR TITLE
Import boto3 different name

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,26 @@ sqs = session.client('sqs')
 assert sqs.list_queues() is not None
 ```
 
+If you use `boto3.client` directly in your code, you can mock it.
+
+```
+import localstack_client.session
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def boto3_localstack_patch(monkeypatch):
+    session_ls = localstack_client.session.Session()
+    monkeypatch.setattr(boto3, "client", session_ls.client)
+    monkeypatch.setattr(boto3, "resource", session_ls.resource)
+```
+
+```
+sqs = boto3.client('sqs')
+assert sqs.list_queues() is not None  # list SQS in localstack
+```
+
+
 ## Developing
 
 We welcome feedback, bug reports, and pull requests!

--- a/localstack_client/session.py
+++ b/localstack_client/session.py
@@ -1,5 +1,7 @@
 import os
-import boto3.session
+from boto3 import session as session_
+from boto3 import client as client_
+from boto3 import resource as resource_
 from botocore.credentials import Credentials
 from localstack_client import config
 
@@ -34,7 +36,7 @@ class Session(object):
         if service_name not in self._service_endpoint_mapping:
             raise Exception('%s is not supported by this mock session.' % (service_name))
 
-        return boto3.client(service_name, endpoint_url=self._service_endpoint_mapping[service_name],
+        return client_(service_name, endpoint_url=self._service_endpoint_mapping[service_name],
                             aws_access_key_id=self.aws_access_key_id,
                             aws_secret_access_key=self.aws_secret_access_key,
                             region_name=self.region_name, verify=False)
@@ -42,7 +44,7 @@ class Session(object):
     def resource(self, service_name, **kwargs):
         if service_name not in self._service_endpoint_mapping:
             raise Exception('%s is not supported by this mock session.' % (service_name))
-        return boto3.resource(service_name,
+        return resource_(service_name,
                               endpoint_url=self._service_endpoint_mapping[service_name],
                               aws_access_key_id=self.aws_access_key_id,
                               aws_secret_access_key=self.aws_secret_access_key,

--- a/localstack_client/session.py
+++ b/localstack_client/session.py
@@ -37,18 +37,18 @@ class Session(object):
             raise Exception('%s is not supported by this mock session.' % (service_name))
 
         return client_(service_name, endpoint_url=self._service_endpoint_mapping[service_name],
-                            aws_access_key_id=self.aws_access_key_id,
-                            aws_secret_access_key=self.aws_secret_access_key,
-                            region_name=self.region_name, verify=False)
+                       aws_access_key_id=self.aws_access_key_id,
+                       aws_secret_access_key=self.aws_secret_access_key,
+                       region_name=self.region_name, verify=False)
 
     def resource(self, service_name, **kwargs):
         if service_name not in self._service_endpoint_mapping:
             raise Exception('%s is not supported by this mock session.' % (service_name))
         return resource_(service_name,
-                              endpoint_url=self._service_endpoint_mapping[service_name],
-                              aws_access_key_id=self.aws_access_key_id,
-                              aws_secret_access_key=self.aws_secret_access_key,
-                              region_name=self.region_name, verify=False)
+                         endpoint_url=self._service_endpoint_mapping[service_name],
+                         aws_access_key_id=self.aws_access_key_id,
+                         aws_secret_access_key=self.aws_secret_access_key,
+                         region_name=self.region_name, verify=False)
 
 
 def _get_default_session():


### PR DESCRIPTION
This pull request change `import boto3.session` with `from boto3 import session as session_`.
It makes easy to patch `boto3.client` and `boto3.resource` call in other source code.

In original implementation, we can not patch `boto3.client` with `localstack.session.Session().client` because `localstack.session` also uses `boto3.client` and it ends with RecursionError.

Importing `boto3.client` with different name will not cause such error when we patch `boto3.client`.

I also added a simple patching sample in README.md Usage section. This PR may relate with Issue #6 
