### PR TITLE
Pass through kwargs to boto3 client and resource creation:

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ if __name__ == '__main__':
 
     setup(
         name='localstack-client',
-        version='1.10',
+        version='1.11',
         description='A lightweight Python client for LocalStack.',
         author='Waldemar Hummer',
         author_email='waldemar.hummer@gmail.com',

--- a/tests/client/test_python_client.py
+++ b/tests/client/test_python_client.py
@@ -1,7 +1,40 @@
 import localstack_client.session
+from botocore.client import Config
 
 
 def test_session():
     session = localstack_client.session.Session()
     sqs = session.client('sqs')
     assert sqs.list_queues() is not None
+
+
+def test_client_kwargs_passed():
+    """ Test kwargs passed through to boto3.client creation """
+    session = localstack_client.session.Session()
+    kwargs = {'config': Config(signature_version='s3v4')}
+    sqs = session.client('sqs', **kwargs)
+    assert sqs.meta.config.signature_version == 's3v4'
+
+
+def test_protected_client_kwargs_not_passed():
+    """ Test protected kwargs not overwritten in boto3.client creation """
+    session = localstack_client.session.Session()
+    kwargs = {'region_name': 'another_region'}
+    sqs = session.client('sqs', **kwargs)
+    assert not sqs.meta.region_name == 'another_region'
+
+
+def test_resource_kwargs_passed():
+    """ Test kwargs passed through to boto3.resource creation """
+    session = localstack_client.session.Session()
+    kwargs = {'config': Config(signature_version='s3v4')}
+    sqs = session.resource('sqs', **kwargs)
+    assert sqs.meta.client.meta.config.signature_version == 's3v4'
+
+
+def test_protected_resource_kwargs_not_passed():
+    """ Test protected kwargs not overwritten in boto3.resource creation """
+    session = localstack_client.session.Session()
+    kwargs = {'region_name': 'another_region'}
+    sqs = session.resource('sqs', **kwargs)
+    assert not sqs.meta.client.meta.region_name == 'another_region'


### PR DESCRIPTION
**CHANGES**
- Adds protected kwargs which are overwritten to allow for localstack connection only
- Adds ability to pass other kwargs through to boto3.client and boto3.resource i.e. config
- Adds unittests for these

**PROBLEM ADDRESSED**
- I was getting errors related to the config passed through in the `boto3.client` creation as the `localstack` client does not allow a config to be passed through. I therefore couldn't get a different `signature_version` to be passed through to match my own usages

**TESTING**
- `config` correctly passed through and solved my initial problem
- Added unittests for this functionality