### PR TITLE
add opensearch to service endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ make test
 
 ## Changelog
 
+* v1.29: Add endpoint for OpenSearch
 * v1.28: Add endpoint for Route53Resolver
 * v1.27: Add endpoint for SESv2
 * v1.25: Remove mapping for deprecated/disabled Web UI on port 8080

--- a/localstack_client/config.py
+++ b/localstack_client/config.py
@@ -15,6 +15,7 @@ _service_endpoints_template = {
     'dynamodb': '{proto}://{host}:4569',
     'dynamodbstreams': '{proto}://{host}:4570',
     'elasticsearch': '{proto}://{host}:4571',
+    'opensearch': '{proto}://{host}:4571',
     's3': '{proto}://{host}:4572',
     'firehose': '{proto}://{host}:4573',
     'lambda': '{proto}://{host}:4574',

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ if __name__ == '__main__':
 
     setup(
         name='localstack-client',
-        version='1.28',
+        version='1.29',
         description='A lightweight Python client for LocalStack.',
         author='LocalStack Team',
         author_email='info@localstack.cloud',


### PR DESCRIPTION
Since we are currently working on supporting AWS OpenSearch, this PR adds the necessary service endpoint template.