### PR TITLE
infrastructure cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ install:           ## Install dependencies in local virtualenv folder
 	(test `which virtualenv` || $(PIP_CMD) install --user virtualenv) && \
 		(test -e $(VENV_DIR) || virtualenv $(VENV_OPTS) $(VENV_DIR)) && \
 		($(VENV_RUN) && $(PIP_CMD) install --upgrade pip) && \
-		(test ! -e requirements.txt || ($(VENV_RUN); $(PIP_CMD) install -r requirements.txt))
+		(test ! -e setup.cfg || ($(VENV_RUN); $(PIP_CMD) install .))
 
 publish:           ## Publish the library to the central PyPi repository
 	# build and upload archive
@@ -21,7 +21,7 @@ test:              ## Run automated tests
 		$(VENV_RUN); DEBUG=$(DEBUG) PYTHONPATH=`pwd` nosetests --with-coverage --logging-level=WARNING --nocapture --no-skip --exe --cover-erase --cover-tests --cover-inclusive --cover-package=localstack_client --with-xunit --exclude='$(VENV_DIR).*' .
 
 lint:              ## Run code linter to check code style
-	($(VENV_RUN); pep8 --max-line-length=100 --ignore=E128 --exclude=node_modules,legacy,$(VENV_DIR),dist .)
+	($(VENV_RUN); pycodestyle --max-line-length=100 --ignore=E128 --exclude=node_modules,legacy,$(VENV_DIR),dist .)
 
 clean:             ## Clean up virtualenv
 	rm -rf $(VENV_DIR)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,0 @@
-boto3
-six

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,36 @@
+[metadata]
+name = localstack-client
+version = 1.29
+url = https://github.com/localstack/localstack-python-client
+author = LocalStack Team
+author_email = info@localstack.cloud
+description = A lightweight Python client for LocalStack.
+license = Apache License 2.0
+classifiers =
+    Programming Language :: Python :: 2
+    Programming Language :: Python :: 2.6
+    Programming Language :: Python :: 2.7
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.3
+    Programming Language :: Python :: 3.4
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    License :: OSI Approved :: Apache Software License
+    Topic :: Software Development :: Testing
+
+[options]
+packages =
+    localstack_client
+
+install_requires =
+    boto3
+    six
+
+[options.extras_require]
+# Dependencies to run the tests
+test =
+    coverage
+    pycodestyle
+    nose

--- a/setup.py
+++ b/setup.py
@@ -1,33 +1,4 @@
 #!/usr/bin/env python
 
 from setuptools import setup
-
-if __name__ == '__main__':
-
-    setup(
-        name='localstack-client',
-        version='1.29',
-        description='A lightweight Python client for LocalStack.',
-        author='LocalStack Team',
-        author_email='info@localstack.cloud',
-        url='https://github.com/localstack/localstack-python-client',
-        packages=['localstack_client'],
-        package_data={},
-        data_files={},
-        install_requires=["boto3"],
-        license="Apache License 2.0",
-        classifiers=[
-            "Programming Language :: Python :: 2",
-            "Programming Language :: Python :: 2.6",
-            "Programming Language :: Python :: 2.7",
-            "Programming Language :: Python :: 3",
-            "Programming Language :: Python :: 3.3",
-            'Programming Language :: Python :: 3.4',
-            'Programming Language :: Python :: 3.6',
-            'Programming Language :: Python :: 3.7',
-            'Programming Language :: Python :: 3.8',
-            'Programming Language :: Python :: 3.9',
-            "License :: OSI Approved :: Apache Software License",
-            "Topic :: Software Development :: Testing",
-        ]
-    )
+setup()


### PR DESCRIPTION
This PR contains a small cleanup of the infrastructure:
* Migrate from `requirements.txt` and `setup.py` to a declarative `setup.cfg`.
  * Both files declared install dependencies, while none were declaring test dependencies.
* Add missing test dependencies (they haven't been declared - neither in `requirements.txt` nor in `setup.py`).
* Migrates from `pep8` to `pycodestyle` (since this is the successor and when using `pep8` today it replaces itself with `pycodestyle` anyways).