### PR TITLE
allow legacy port handling for OpenSearch, simplify pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,21 +27,13 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Upgrade pip version
-        run: |
-          python3 -m pip install --upgrade pip
+        run: python3 -m pip install --upgrade pip
 
       - name: Install Dependencies
-        run: |
-          make install
-
-      - name: Test
-        run: |
-          pip install pep8 nose boto3 localstack
-          docker pull localstack/localstack
-          localstack start -d
-          make test
+        run: make install
 
       - name: Lint
-        run: |
-          pip install pycodestyle
-          make lint
+        run: make lint
+
+      - name: Test
+        run: make test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # LocalStack Python Client Change Log
 
+* v1.30: Allow legacy port handling for OpenSearch (to support `OPENSEARCH_ENDPOINT_STRATEGY=off`)
 * v1.29: Add endpoint for OpenSearch
 * v1.28: Add endpoint for Route53Resolver
 * v1.27: Add endpoint for SESv2

--- a/Makefile
+++ b/Makefile
@@ -9,16 +9,15 @@ install:           ## Install dependencies in local virtualenv folder
 	(test `which virtualenv` || $(PIP_CMD) install --user virtualenv) && \
 		(test -e $(VENV_DIR) || virtualenv $(VENV_OPTS) $(VENV_DIR)) && \
 		($(VENV_RUN) && $(PIP_CMD) install --upgrade pip) && \
-		(test ! -e setup.cfg || ($(VENV_RUN); $(PIP_CMD) install .))
+		(test ! -e setup.cfg || ($(VENV_RUN); $(PIP_CMD) install .[test]))
 
 publish:           ## Publish the library to the central PyPi repository
 	# build and upload archive
 	($(VENV_RUN) && ./setup.py sdist upload)
 
 test:              ## Run automated tests
-	make lint && \
-		($(VENV_RUN); test `which localstack` || pip install localstack) && \
-		$(VENV_RUN); DEBUG=$(DEBUG) PYTHONPATH=`pwd` nosetests --with-coverage --logging-level=WARNING --nocapture --no-skip --exe --cover-erase --cover-tests --cover-inclusive --cover-package=localstack_client --with-xunit --exclude='$(VENV_DIR).*' .
+	($(VENV_RUN); test `which localstack` || pip install .[test]) && \
+	$(VENV_RUN); DEBUG=$(DEBUG) PYTHONPATH=`pwd` nosetests --with-coverage --logging-level=WARNING --nocapture --no-skip --exe --cover-erase --cover-tests --cover-inclusive --cover-package=localstack_client --with-xunit --exclude='$(VENV_DIR).*' .
 
 lint:              ## Run code linter to check code style
 	($(VENV_RUN); pycodestyle --max-line-length=100 --ignore=E128 --exclude=node_modules,legacy,$(VENV_DIR),dist .)

--- a/localstack_client/config.py
+++ b/localstack_client/config.py
@@ -110,7 +110,7 @@ _service_endpoints_template = {
 # TODO remove service port mapping above entirely
 if os.environ.get('USE_LEGACY_PORTS') not in ['1', 'true']:
     for key, value in _service_endpoints_template.items():
-        if key not in ['dashboard', 'elasticsearch']:
+        if key not in ['dashboard', 'elasticsearch', 'opensearch']:
             _service_endpoints_template[key] = '%s:%s' % (value.rpartition(':')[0], EDGE_PORT)
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = localstack-client
-version = 1.29
+version = 1.30
 url = https://github.com/localstack/localstack-python-client
 author = LocalStack Team
 author_email = info@localstack.cloud
@@ -34,3 +34,4 @@ test =
     coverage
     pycodestyle
     nose
+    localstack

--- a/tests/client/__init__.py
+++ b/tests/client/__init__.py
@@ -7,12 +7,9 @@ STATE = {}
 def setup_package():
     if STATE.get('process'):
         return
-    STATE['process'] = subprocess.Popen(['localstack', 'start'])
-    time.sleep(10)
+    STATE['process'] = subprocess.Popen(['localstack', 'start', '-d'])
+    subprocess.Popen(['localstack', 'wait']).wait()
 
 
 def teardown_package():
-    # TODO implement "stop" command in LocalStack!
-    # subprocess.check_call('localstack stop', shell=True)
-    STATE['process'].terminate()
-    time.sleep(2)
+    subprocess.Popen(['localstack', 'stop']).wait()


### PR DESCRIPTION
This PR contains the following changes:
- Allows the legacy port handling for OpenSearch (in order to support the `OPENSEARCH_ENDPOINT_STRATEGY=off` in LocalStack, similar to the ElasticSearch feature).
- Simplifies the pipeline (removes pip installs and instead installs the `test` extra with `make install`).
- Prepares the release of v1.30.