### PR TITLE
ci: drop support for python 3.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,6 @@ jobs:
           - "3.9"
           - "3.8"
           - "3.7"
-          - "3.6"
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
https://discuss.python.org/t/is-python-3-6-eol/12765/2