### PR TITLE
Consider `AWS_ENDPOINT_URL` configuration when resolving service endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # LocalStack Python Client Change Log
 
+* v2.1: Consider `AWS_ENDPOINT_URL` configuration when resolving service endpoints
 * v2.0: Change `LOCALSTACK_HOSTNAME` from `<hostname>` to `<hostname>:<port>`; remove `EDGE_PORT` environment variable
 * v1.39: Add endpoint for Amazon MQ
 * v1.38: Add `enable_local_endpoints()` util function; slight project refactoring, migrate from `nose` to `pytests`

--- a/README.md
+++ b/README.md
@@ -70,8 +70,9 @@ assert sqs.list_queues() is not None  # list SQS in localstack
 
 You can use the following environment variables for configuration:
 
-* `LOCALSTACK_HOST`: A `<hostname>:<port>` variable defining where to find LocalStack (default: `localhost:4566`).
-* `USE_SSL`: Whether to use SSL when connecting to LocalStack (default: `False`).
+* `AWS_ENDPOINT_URL`: The endpoint URL to connect to (takes precedence over `USE_SSL`/`LOCALSTACK_HOST` below)
+* `LOCALSTACK_HOST` (deprecated): A `<hostname>:<port>` variable defining where to find LocalStack (default: `localhost:4566`).
+* `USE_SSL` (deprecated): Whether to use SSL when connecting to LocalStack (default: `False`).
 
 ### Enabling Transparent Local Endpoints
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = localstack-client
-version = 2.0
+version = 2.1
 url = https://github.com/localstack/localstack-python-client
 author = LocalStack Team
 author_email = info@localstack.cloud


### PR DESCRIPTION
This PR adds minor enhancements to have proper handling of the `AWS_ENDPOINT_URL` configuration. Previously we were only using it for the `get_service_endpoint(..)` function, but not for `get_service_endpoints(..)`. This was leading to issues when using the 

Summary of changes:
* move logic around `AWS_ENDPOINT_URL` into get_service_endpoints(..)
* call `get_service_endpoints(..)` from `get_service_endpoint(..)`, and select the corresponding service entry from the dict. There is a tiny performance penalty in this approach, which seems acceptable given that it allows us to keep the endpoint construction logic in a central place. (this now also works transitively for `get_service_ports(..)`)
* update docs to cover `$AWS_ENDPOINT_URL` configuration

Side note: Overall, this library (esp. the host/port handling bit) should soon become obsolete (there's already a draft PR to remove it from LocalStack core, and we should eliminate it from `awslocal` soon as well).