### PR TITLE
Add endpoint configs for emr-serverless and a few other services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # LocalStack Python Client Change Log
 
+* v2.2: Add endpoint configs for `emr-serverless` and a few other services
 * v2.1: Consider `AWS_ENDPOINT_URL` configuration when resolving service endpoints
 * v2.0: Change `LOCALSTACK_HOSTNAME` from `<hostname>` to `<hostname>:<port>`; remove `EDGE_PORT` environment variable
 * v1.39: Add endpoint for Amazon MQ

--- a/localstack_client/config.py
+++ b/localstack_client/config.py
@@ -115,6 +115,10 @@ _service_ports: Dict[str, int] = {
     "meteringmarketplace": 4644,
     "transcribe": 4566,
     "mq": 4566,
+    "emr-serverless": 4566,
+    "appflow": 4566,
+    "route53domains": 4566,
+    "keyspaces": 4566,
 }
 
 # TODO remove service port mapping above entirely

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = localstack-client
-version = 2.1
+version = 2.2
 url = https://github.com/localstack/localstack-python-client
 author = LocalStack Team
 author_email = info@localstack.cloud


### PR DESCRIPTION
Add endpoint configs for `emr-serverless` and a few other services (mostly feature requests from the localstack/localstack repo). Really looking forward to phasing out these client configs soon and not requiring to update the dict anymore :)