### PR TITLE
update ci python version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
-  workflow_dispatch
+  workflow_dispatch:
 
 jobs:
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  workflow_dispatch
 
 jobs:
   test:
@@ -13,10 +14,12 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
+          - "3.13"
+          - "3.12"
+          - "3.11"
           - "3.10"
           - "3.9"
           - "3.8"
-          - "3.7"
 
     steps:
       - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # LocalStack Python Client Change Log
 
+* v2.8: Removes support for python `3.6` and `3.7` and adds `3.12` and `3.13` for parity with boto3
 * v2.7: Add endpoint config for EventBridge Pipes
 * v2.6: Add endpoint config for Pinpoint
 * v2.5: Add endpoint config for AppConfig Data

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = localstack-client
-version = 2.7
+version = 2.8
 url = https://github.com/localstack/localstack-python-client
 author = LocalStack Team
 author_email = info@localstack.cloud
@@ -8,12 +8,12 @@ description = A lightweight Python client for LocalStack.
 license = Apache License 2.0
 classifiers =
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
     License :: OSI Approved :: Apache Software License
     Topic :: Software Development :: Testing
 


### PR DESCRIPTION
# Motivation

[Boto3](https://pypi.org/project/boto3/) no longer explicitly support python 3.7 and lower, so it seems fair to remove it from our ci and pypi package.

Also adding support for newer version of python and a `workflow_dispatch` to allow triggering the the ci manually.

