### PR TITLE
Add S3 tables to list of supported services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # LocalStack Python Client Change Log
 
+* v2.11: Add endpoint config for S3 Tables
 * v2.10: Remove endpoints for 'bedrock-runtime' and 'textract' because overriding them is not supported by the AWS Terraform provider
 * v2.9: Add endpoints for Account Management, Private Certificate Authority, Bedrock, CloudControl, CodeBuild, CodeCommit, CodeConnections, CodeDeploy, CodePipeline, ElasticTranscoder, MemoryDB, Shield, Textract and Verified Permissions
 * v2.8: Removes support for python `3.6` and `3.7` and adds `3.12` and `3.13` for parity with boto3

--- a/localstack_client/config.py
+++ b/localstack_client/config.py
@@ -113,6 +113,7 @@ _service_ports: Dict[str, int] = {
     "route53resolver": 4580,
     "s3": 4572,
     "s3control": 4627,
+    "s3tables": 4566,
     "sagemaker": 4609,
     "sagemaker-runtime": 4609,
     "scheduler": 4566,

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = localstack-client
-version = 2.10
+version = 2.11
 url = https://github.com/localstack/localstack-python-client
 author = LocalStack Team
 author_email = info@localstack.cloud


### PR DESCRIPTION
Add S3 Tables to the list of supported services so that `tflocal` can work with S3 Tables