### PR TITLE
Add endpoint config for Amazon Aurora DSQL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # LocalStack Python Client Change Log
 
+* v2.12: Add endpoint config for Amazon Aurora DSQL
 * v2.11: Add endpoint config for S3 Tables
 * v2.10: Remove endpoints for 'bedrock-runtime' and 'textract' because overriding them is not supported by the AWS Terraform provider
 * v2.9: Add endpoints for Account Management, Private Certificate Authority, Bedrock, CloudControl, CodeBuild, CodeCommit, CodeConnections, CodeDeploy, CodePipeline, ElasticTranscoder, MemoryDB, Shield, Textract and Verified Permissions

--- a/localstack_client/config.py
+++ b/localstack_client/config.py
@@ -49,6 +49,7 @@ _service_ports: Dict[str, int] = {
     "config": 4641,
     "configservice": 4641,
     "docdb": 4594,
+    "dsql": 4566,
     "dynamodb": 4569,
     "dynamodbstreams": 4570,
     "ec2": 4597,

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = localstack-client
-version = 2.11
+version = 2.12
 url = https://github.com/localstack/localstack-python-client
 author = LocalStack Team
 author_email = info@localstack.cloud


### PR DESCRIPTION
Hi😀

LocalStack for AWS 2026.06.0 added support for Amazon Aurora DSQL.
https://blog.localstack.cloud/localstack-for-aws-release-2026-06-0/

This PR adds the `dsql` service to the endpoint configuration so that it can be used through `localstack_client`.
The changes follow the same pattern as a recent PR.
- https://github.com/localstack/localstack-python-client/pull/58

I also verified the change locally and it works good.

```python
import localstack_client.session as session

try:
    dsql = session.Session().client('dsql')
except Exception as e:
    print(f"client('dsql') -> {e}")
    raise SystemExit(1)

print(f"client('dsql') -> endpoint: {dsql.meta.endpoint_url}")
```

```sh
$ PYTHONPATH=~/ghq/github.com/kakakakakku/localstack-python-client uv run main.py
client('dsql') -> endpoint: http://localhost:4566
```

Thank you!