### PR TITLE
fix: use python -m build in make publish, drop setup.py

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,3 +40,5 @@ jobs:
 
       - name: Test
         run: make test
+        env:
+          LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,10 @@ install:           ## Install dependencies in local virtualenv folder
 
 publish:           ## Publish the library to the central PyPi repository
 	# build and upload archive
-	$(VENV_RUN); ./setup.py sdist && twine upload $(BUILD_DIR)/*.tar.gz
+	rm -rf $(BUILD_DIR)
+	$(VENV_RUN); $(PIP_CMD) install --upgrade build twine && \
+		python -m build --sdist --wheel && \
+		twine upload $(BUILD_DIR)/*
 
 test:              ## Run automated tests
 	($(VENV_RUN); test `which localstack` || pip install .[test]) && \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,0 @@
-#!/usr/bin/env python
-
-from setuptools import setup
-setup()


### PR DESCRIPTION
## Summary
- `make publish` used `./setup.py sdist`, which produces a hyphenated sdist filename (`localstack-client-X.Y.tar.gz`); PyPI now enforces PEP 625 normalized filenames (underscore) and rejects the upload with a 400.
- Switched to `python -m build --sdist --wheel`, which produces correctly named artifacts and also builds a wheel (previously only an sdist was published).
- Removed `setup.py` (was just a `setup()` shim) and added a minimal `pyproject.toml` declaring the setuptools build backend, since `python -m build` needs one or the other present. `setup.cfg` still holds all package metadata, untouched.

Discovered this while publishing v2.12 — upload failed with:
```
400 Filename 'localstack-client-2.12.tar.gz' is invalid, should be 'localstack_client-2.12.tar.gz'.
```

## Test plan
- [x] `python -m build --sdist --wheel` produces `localstack_client-2.12.tar.gz` + `.whl` with correct normalized names
- [x] `twine check dist/*` passes
- [x] `make lint` passes
- [x] `make test` passes (10/10, same as before this change)